### PR TITLE
Thread participants CRUD - part 1

### DIFF
--- a/AcsEmulator/AcsEmulatorAPI/Chat.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Chat.cs
@@ -62,9 +62,9 @@ namespace AcsEmulatorAPI
 
 			app.MapPost(
 				"/chat/threads/{chatThreadId}/participants/:add",
-				async (HttpContext context, AcsDbContext db, string chatThreadId, AddChatParticipantsRequest req) =>
+				[Authorize] async (ClaimsPrincipal principal, AcsDbContext db, string chatThreadId, AddChatParticipantsRequest req) =>
 				{
-					string userRawId = GetRawId(context, app.Configuration);
+					string userRawId = principal.Claims.First(x => x.Type == "skypeid").Value;
 
 					var thisThread = await db.ChatThreads.FindAsync(chatThreadId);
 

--- a/AcsEmulator/AcsEmulatorAPI/Chat.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Chat.cs
@@ -57,6 +57,30 @@ namespace AcsEmulatorAPI
 					value = threads
 				});
 			});
+
+			app.MapPost(
+				"/chat/threads/{chatThreadId}/participants/:add",
+				async (HttpContext context, AcsDbContext db, string chatThreadId, AddChatParticipantsRequest req) =>
+				{
+					string userRawId = GetRawId(context, app.Configuration);
+
+					var thisThread = await db.ChatThreads.FindAsync(chatThreadId);
+
+					if (thisThread == null)
+					{
+						return Results.NotFound();
+					}
+
+					if (thisThread.CreatedBy.RawId != userRawId)
+					{
+						return Results.Forbid();
+					}
+
+					return Results.Ok();
+
+					//var idsToAdd = req.Participants.Select(p => p.)
+					//var participantsToAdd = db.Users.Where(u => req.Participants.)
+				});
 		}
 
 		private static string GetRawId(HttpContext context, IConfiguration config)

--- a/AcsEmulator/AcsEmulatorAPI/Migrations/20220921213734_AddChatThreadParticipants.Designer.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Migrations/20220921213734_AddChatThreadParticipants.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AcsEmulatorAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AcsEmulatorAPI.Migrations
 {
     [DbContext(typeof(AcsDbContext))]
-    partial class AcsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220921213734_AddChatThreadParticipants")]
+    partial class AddChatThreadParticipants
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.9");

--- a/AcsEmulator/AcsEmulatorAPI/Migrations/20220921213734_AddChatThreadParticipants.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Migrations/20220921213734_AddChatThreadParticipants.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AcsEmulatorAPI.Migrations
+{
+    public partial class AddChatThreadParticipants : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserChatThread",
+                columns: table => new
+                {
+                    UserId = table.Column<string>(type: "TEXT", nullable: false),
+                    ChatThreadId = table.Column<string>(type: "TEXT", nullable: false),
+                    DisplayName = table.Column<string>(type: "TEXT", nullable: false),
+                    ShareHistoryTime = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserChatThread", x => new { x.UserId, x.ChatThreadId });
+                    table.ForeignKey(
+                        name: "FK_UserChatThread_ChatThreads_ChatThreadId",
+                        column: x => x.ChatThreadId,
+                        principalTable: "ChatThreads",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_UserChatThread_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_UserChatThread_ChatThreadId",
+                table: "UserChatThread",
+                column: "ChatThreadId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserChatThread");
+        }
+    }
+}

--- a/AcsEmulator/AcsEmulatorAPI/Models/AcsDbContext.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/AcsDbContext.cs
@@ -18,7 +18,26 @@ namespace AcsEmulatorAPI.Models
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
-            base.OnModelCreating(builder);
+            builder.Entity<ChatThread>()
+                .HasOne(t => t.CreatedBy)
+                .WithMany();
+
+            builder.Entity<User>()
+                .HasMany(u => u.Threads)
+                .WithMany(t => t.Participants)
+                .UsingEntity<UserChatThread>(
+                    j => j
+                        .HasOne(uct => uct.ChatThread)
+                        .WithMany(t => t.UserChatThreads)
+                        .HasForeignKey(uct => uct.ChatThreadId),
+                    j => j
+                        .HasOne(uct => uct.User)
+                        .WithMany(u => u.UserChatThreads)
+                        .HasForeignKey(uct => uct.UserId),
+                    j =>
+                    {
+                        j.HasKey(uct => new { uct.UserId, uct.ChatThreadId });
+                    });
         }
     }
 }

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatModels.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatModels.cs
@@ -8,4 +8,6 @@
 		DateTimeOffset ShareHistoryTime);
 
 	record CreateChatThreadRequest(string Topic, List<ChatParticipant> Participants);
+
+	record AddChatParticipantsRequest(List<ChatParticipant> Participants);
 }

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatModels.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatModels.cs
@@ -1,13 +1,13 @@
 ﻿namespace AcsEmulatorAPI.Models
 {
-	record CommunicationIdentifier(string RawId);
+	public record CommunicationIdentifier(string RawId);
 
-	record ChatParticipant(
+	public record ChatParticipant(
 		CommunicationIdentifier CommunicationIdentifier,
 		string DisplayName,
 		DateTimeOffset ShareHistoryTime);
 
-	record CreateChatThreadRequest(string Topic, List<ChatParticipant> Participants);
+	public record CreateChatThreadRequest(string Topic, List<ChatParticipant> Participants);
 
-	record AddChatParticipantsRequest(List<ChatParticipant> Participants);
+	public record AddChatParticipantsRequest(List<ChatParticipant> Participants);
 }

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
@@ -12,7 +12,8 @@ namespace AcsEmulatorAPI.Models
 
 		public User CreatedBy { get; set; }
 
-		public ICollection<User> Participants { get; set; }
+		public virtual ICollection<User> Participants { get; set; }
+		public virtual List<UserChatThread> UserChatThreads { get; set; }
 
 		public static ChatThread CreateNew(string topic, User createdBy)
 		{

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
@@ -1,5 +1,7 @@
 ﻿#nullable disable
 
+using Microsoft.EntityFrameworkCore;
+
 namespace AcsEmulatorAPI.Models
 {
 	public class ChatThread
@@ -22,8 +24,45 @@ namespace AcsEmulatorAPI.Models
 				Id = $"19:{Guid.NewGuid()}",
 				Topic = topic,
 				CreatedOn = DateTimeOffset.Now,
-				CreatedBy = createdBy
+				CreatedBy = createdBy,
+
+				Participants = new List<User>(),
+				UserChatThreads = new List<UserChatThread>()
 			};
+		}
+
+		// TODO: maybe shouldn't pass db context
+		public async Task AddParticipants(AcsDbContext db, IEnumerable<ChatParticipant> participants)
+		{
+			foreach (var requestParticipant in participants)
+			{
+				// TODO: Not efficient to look up in a loop
+				var participantToAdd = await db.Users
+					.Include(u => u.Threads)
+					.Include(u => u.UserChatThreads)
+					.FirstOrDefaultAsync(u => u.RawId == requestParticipant.CommunicationIdentifier.RawId);
+
+				if (participantToAdd == null)
+				{
+					// TODO: add to "invalidParticipants"
+					continue;
+				}
+
+				var uct = new UserChatThread
+				{
+					User = participantToAdd,
+					ChatThread = this,
+
+					ShareHistoryTime = requestParticipant.ShareHistoryTime,
+					DisplayName = requestParticipant.DisplayName
+				};
+
+				Participants.Add(participantToAdd);
+				UserChatThreads.Add(uct);
+
+				participantToAdd.Threads.Add(this);
+				participantToAdd.UserChatThreads.Add(uct);
+			}
 		}
 	}
 }

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
@@ -12,6 +12,8 @@ namespace AcsEmulatorAPI.Models
 
 		public User CreatedBy { get; set; }
 
+		public ICollection<User> Participants { get; set; }
+
 		public static ChatThread CreateNew(string topic, User createdBy)
 		{
 			return new ChatThread

--- a/AcsEmulator/AcsEmulatorAPI/Models/User.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/User.cs
@@ -11,7 +11,8 @@ namespace AcsEmulatorAPI.Models
         [Key]
         public string RawId { get; set; }
 
-        public ICollection<ChatThread> Threads { get; set; }
+        public virtual ICollection<ChatThread> Threads { get; set; }
+        public virtual List<UserChatThread> UserChatThreads { get; set; }
 
         public static User CreateNew(string resourceId)
         {

--- a/AcsEmulator/AcsEmulatorAPI/Models/User.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/User.cs
@@ -11,6 +11,8 @@ namespace AcsEmulatorAPI.Models
         [Key]
         public string RawId { get; set; }
 
+        public ICollection<ChatThread> Threads { get; set; }
+
         public static User CreateNew(string resourceId)
         {
             string userId = Guid.NewGuid().ToString();

--- a/AcsEmulator/AcsEmulatorAPI/Models/UserChatThread.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/UserChatThread.cs
@@ -1,0 +1,15 @@
+﻿namespace AcsEmulatorAPI.Models
+{
+	public class UserChatThread
+	{
+		public string DisplayName { get; set; }
+
+		public DateTimeOffset ShareHistoryTime { get; set; }
+
+		public string UserId { get; set; }
+		public User User { get; set; }
+
+		public string ChatThreadId { get; set; }
+		public ChatThread ChatThread { get; set; }
+	}
+}


### PR DESCRIPTION
Added:

* `POST /chat/threads/{chatThreadId}/participants/:add`

* `GET /chat/threads/{chatThreadId}/participants`

Note, when you create a thread, you now need to provide yourself as a participant explicitly, I wasn't sure if it was the case in reality, or if creator gets auto-added. But if they do, what is their displayName?

```json
{
  "topic": "My topic",
  "participants": [
    {
      "communicationIdentifier": {
        "rawId": "8:acs:d9b2f18a-2c34-415e-889d-c210cb738186_09768748-a0b5-478d-a472-75faf09e04b0"
      },
      "displayName": "Bob",
      "shareHistoryTime": "2022-09-20T22:37:58.982Z"
    }
  ]
}
```

O opted for having an explicit `UserChatThread` entity that stores `(UserId, ThreadId, DisplayName, ShareHistoryTime)`. As I am writing this I just realized that maybe I don't need to do this boilerplate explicitly:
```csharp
var uct = new UserChatThread
{
    User = participantToAdd,
    ChatThread = this,

    ShareHistoryTime = requestParticipant.ShareHistoryTime,
    DisplayName = requestParticipant.DisplayName
};

Participants.Add(participantToAdd);
UserChatThreads.Add(uct);
```
^ maybe EF could automatically do the `Participants.Add(...)` part, but I am not sure. I will play around with it. Maybe `Participants` isn't actually needed after all, since we have the `UserChatThreads` collection instead.