### PR TITLE
Adding participant to a thread will generate a message

### DIFF
--- a/AcsEmulator/AcsEmulatorAPI/AcsEmulatorAPI.csproj
+++ b/AcsEmulator/AcsEmulatorAPI/AcsEmulatorAPI.csproj
@@ -12,6 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="6.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.23.1" />

--- a/AcsEmulator/AcsEmulatorAPI/ChatController.cs
+++ b/AcsEmulator/AcsEmulatorAPI/ChatController.cs
@@ -32,7 +32,7 @@ namespace AcsEmulatorAPI
 					participants.Add(new ChatParticipant(new CommunicationIdentifier(userRawId), null, null));
 				}
 
-				await t.AddParticipants(db, participants);
+				await t.AddParticipants(db, user, participants);
 
 				await db.ChatThreads.AddAsync(t);
 				await db.SaveChangesAsync();

--- a/AcsEmulator/AcsEmulatorAPI/Migrations/20220922174028_AddParticipantsAddedMessage.Designer.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Migrations/20220922174028_AddParticipantsAddedMessage.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AcsEmulatorAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AcsEmulatorAPI.Migrations
 {
     [DbContext(typeof(AcsDbContext))]
-    partial class AcsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220922174028_AddParticipantsAddedMessage")]
+    partial class AddParticipantsAddedMessage
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.9");

--- a/AcsEmulator/AcsEmulatorAPI/Migrations/20220922174028_AddParticipantsAddedMessage.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Migrations/20220922174028_AddParticipantsAddedMessage.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AcsEmulatorAPI.Migrations
+{
+    public partial class AddParticipantsAddedMessage : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AddParticipantsChatMessages",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AddParticipantsChatMessages", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AddParticipantsChatMessages_ChatMessages_Id",
+                        column: x => x.Id,
+                        principalTable: "ChatMessages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AddedParticipant",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "TEXT", nullable: false),
+                    ParticipantRawId = table.Column<string>(type: "TEXT", nullable: false),
+                    DisplayName = table.Column<string>(type: "TEXT", nullable: true),
+                    ShareHistoryTime = table.Column<DateTimeOffset>(type: "TEXT", nullable: true),
+                    AddParticipantsChatMessageId = table.Column<Guid>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AddedParticipant", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_AddedParticipant_AddParticipantsChatMessages_AddParticipantsChatMessageId",
+                        column: x => x.AddParticipantsChatMessageId,
+                        principalTable: "AddParticipantsChatMessages",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_AddedParticipant_Users_ParticipantRawId",
+                        column: x => x.ParticipantRawId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AddedParticipant_AddParticipantsChatMessageId",
+                table: "AddedParticipant",
+                column: "AddParticipantsChatMessageId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AddedParticipant_ParticipantRawId",
+                table: "AddedParticipant",
+                column: "ParticipantRawId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AddedParticipant");
+
+            migrationBuilder.DropTable(
+                name: "AddParticipantsChatMessages");
+        }
+    }
+}

--- a/AcsEmulator/AcsEmulatorAPI/Models/AcsDbContext.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/AcsDbContext.cs
@@ -18,7 +18,10 @@ namespace AcsEmulatorAPI.Models
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
-            builder.Entity<ChatThread>()
+            builder.Entity<ChatMessage>().ToTable("ChatMessages");
+			builder.Entity<AddParticipantsChatMessage>().ToTable("AddParticipantsChatMessages");
+
+			builder.Entity<ChatThread>()
                 .HasOne(t => t.CreatedBy)
                 .WithMany();
 

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatMessage.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatMessage.cs
@@ -2,7 +2,7 @@
 
 namespace AcsEmulatorAPI.Models
 {
-	[Table("ChatMessages")]
+	//[Table("ChatMessages")]
 	public class ChatMessage
 	{
 		public Guid Id { get; set; }
@@ -11,12 +11,29 @@ namespace AcsEmulatorAPI.Models
 
 		public ChatMessageType Type { get; set; }
 
-		public User Sender { get; set; }
+		public virtual User Sender { get; set; }
 
 		public string? SenderDisplayName { get; set; }
 
 		public DateTimeOffset CreatedOn { get; set; } = DateTimeOffset.UtcNow;
 
 		public int SequenceId { get; set; }
+	}
+
+	//[Table("AddParticipantsChatMessages")]
+	public class AddParticipantsChatMessage: ChatMessage
+	{
+		public virtual ICollection<AddedParticipant> AddedParticipants { get; set; }
+	}
+
+	public class AddedParticipant
+	{
+		public Guid Id { get; set; }
+
+		public virtual User Participant { get; set; }
+
+		public string? DisplayName { get; set; }
+
+		public DateTimeOffset? ShareHistoryTime { get; set; }
 	}
 }

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
@@ -1,6 +1,8 @@
 ﻿#nullable disable
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using System.Reflection;
 
 namespace AcsEmulatorAPI.Models
 {
@@ -12,7 +14,7 @@ namespace AcsEmulatorAPI.Models
 
 		public DateTimeOffset CreatedOn { get; set; }
 
-		public User CreatedBy { get; set; }
+		public virtual User CreatedBy { get; set; }
 
 		public virtual ICollection<User> Participants { get; set; }
 		public virtual List<UserChatThread> UserChatThreads { get; set; }
@@ -28,12 +30,13 @@ namespace AcsEmulatorAPI.Models
 				CreatedOn = DateTimeOffset.UtcNow,
 				CreatedBy = createdBy,
 				Participants = new List<User>(),
-				UserChatThreads = new List<UserChatThread>()
+				UserChatThreads = new List<UserChatThread>(),
+				Messages = new List<ChatMessage>()
 			};
 		}
 
 		// TODO: maybe shouldn't pass db context
-		public async Task AddParticipants(AcsDbContext db, IEnumerable<ChatParticipant> participants)
+		public async Task AddParticipants(AcsDbContext db, User initiator, IEnumerable<ChatParticipant> participants)
 		{
 			foreach (var requestParticipant in participants)
 			{
@@ -57,6 +60,31 @@ namespace AcsEmulatorAPI.Models
 					ShareHistoryTime = requestParticipant.ShareHistoryTime,
 					DisplayName = requestParticipant.DisplayName
 				};
+
+				// Send a "participant added" message to the thread
+				int nextSequenceId = Messages.Count + 1;
+				var apm = new AddParticipantsChatMessage
+				{
+					// TODO: where is this Content used?
+					Content = $"Participant {requestParticipant.DisplayName ?? "Unknown"} added",
+
+					Sender = initiator,
+					Type = ChatMessageType.ParticipantAdded,
+					SequenceId = nextSequenceId,
+
+					AddedParticipants = new List<AddedParticipant>
+					{
+						// TODO: duplicating "UserChatThread" - ok or not?
+						new AddedParticipant
+						{
+							Participant = participantToAdd,
+
+							ShareHistoryTime = requestParticipant.ShareHistoryTime,
+							DisplayName = requestParticipant.DisplayName
+						}
+					}
+				};
+				Messages.Add(apm);
 
 				Participants.Add(participantToAdd);
 				UserChatThreads.Add(uct);

--- a/AcsEmulator/AcsEmulatorAPI/Models/UserChatThread.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/UserChatThread.cs
@@ -7,9 +7,9 @@
 		public DateTimeOffset? ShareHistoryTime { get; set; }
 
 		public string UserId { get; set; }
-		public User User { get; set; }
+		public virtual User User { get; set; }
 
 		public string ChatThreadId { get; set; }
-		public ChatThread ChatThread { get; set; }
+		public virtual ChatThread ChatThread { get; set; }
 	}
 }

--- a/AcsEmulator/AcsEmulatorAPI/Program.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Program.cs
@@ -7,8 +7,9 @@ using Microsoft.OpenApi.Models;
 var builder = WebApplication.CreateBuilder(args);
 
 var connectionString = builder.Configuration.GetConnectionString("EmulatorDb");
-builder.Services.AddDbContext<AcsDbContext>(options =>
-	options.UseSqlite(connectionString));
+builder.Services.AddDbContext<AcsDbContext>(options => options
+	.UseLazyLoadingProxies()
+	.UseSqlite(connectionString));
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
 	.AddJwtBearer(o => o.TokenValidationParameters = UserToken.GetTokenValidationParameters(builder.Configuration["JwtSigningKey"]));


### PR DESCRIPTION
* Added basic ability to generate a thread message when a participant is added

* Introduced inheritance into the DB hierarchy 😮 : `AddParticipantsChatMessage: ChatMessage`

In the [chat service Swagger](https://github.com/Azure/azure-rest-api-specs/blob/main/specification/communication/data-plane/Chat/stable/2021-09-07/communicationserviceschat.json), for returned messages the [`ChatMessageContent`](https://github.com/Azure/azure-rest-api-specs/blob/7d5d1db0c45d6fe0934c97b6a6f9bb34112d42d1/specification/communication/data-plane/Chat/stable/2021-09-07/communicationserviceschat.json#L1360) type looks like below. For the messages of type "participantAdded" it contains `ChartParticipant(CommunicationIdentifier, DisplayName, ShareHistoryTime)`. I chose to store this information _again_ in the message (via the new `AddParticipantsChatMessage.AddedParticipants`), which duplicates the existing `UserChatThread`. 😞 

In theory, `AddParticipantsChatMessage` could reference a `UserChatThread` entry, but I am not sure how that would work in a hypothetical scenario where participant gets added then removed and then added again. There should be only one `UserChatThread` in this case, but multiple `AddParticipantsChatMessage` entries... The deeper I look into our chat model the more confused I get 🤣 

```json
"ChatMessageContent": {
    "description": "Content of a chat message.",
    "type": "object",
    "properties": {
    "message": {
        "description": "Chat message content for messages of types text or html.",
        "type": "string",
        "example": "Come one guys, lets go for lunch together."
    },
    "topic": {
        "description": "Chat message content for messages of type topicUpdated.",
        "type": "string",
        "example": "Lunch Chat thread"
    },
    "participants": {
        "description": "Chat message content for messages of types participantAdded or participantRemoved.",
        "type": "array",
        "items": {
        "$ref": "#/definitions/ChatParticipant"
        }
    },
    "initiatorCommunicationIdentifier": {
        "$ref": "#/definitions/CommunicationIdentifierModel"
    }
    }
},
```

Anyway, the `https://localhost/chat/threads/{{threadId}}/messages` endpoint is now capable of returning this:
```json
[
    {
        "id": "082f1d49-d7b5-4a60-a46b-a271883f826a",
        "type": "text",
        "sequenceId": "2",
        "versionId": "1",
        "content": {
            "message": "Hello thread",
            "participants": null
        },
        "senderDisplayName": "Emil the Emulator",
        "createdOn": "2022-09-22T18:27:20.1973091+00:00",
        "senderCommunicationIdentifier": {
            "rawId": "8:acs:d9b2f18a-2c34-415e-889d-c210cb738186_c41af59c-d6da-40bc-8b12-66c3b9ab4712"
        }
    },
    {
        "id": "3222d70e-98ec-40a2-847b-c019159ffd94",
        "type": "text",
        "sequenceId": "3",
        "versionId": "1",
        "content": {
            "message": "I am sending messages",
            "participants": null
        },
        "senderDisplayName": "Emil the Emulator",
        "createdOn": "2022-09-22T18:27:23.5120831+00:00",
        "senderCommunicationIdentifier": {
            "rawId": "8:acs:d9b2f18a-2c34-415e-889d-c210cb738186_c41af59c-d6da-40bc-8b12-66c3b9ab4712"
        }
    },
    {
        "id": "39d7132c-e8c1-4f2b-bbb2-45dfc66c7d60",
        "type": "participantAdded",
        "sequenceId": "1",
        "versionId": "1",
        "content": {
            "message": "Participant Unknown added",
            "participants": [
                {
                    "communicationIdentifier": {
                        "rawId": "8:acs:d9b2f18a-2c34-415e-889d-c210cb738186_c41af59c-d6da-40bc-8b12-66c3b9ab4712"
                    },
                    "displayName": null,
                    "shareHistoryTime": null
                }
            ]
        },
        "senderDisplayName": null,
        "createdOn": "2022-09-22T18:27:13.1339649+00:00",
        "senderCommunicationIdentifier": {
            "rawId": "8:acs:d9b2f18a-2c34-415e-889d-c210cb738186_c41af59c-d6da-40bc-8b12-66c3b9ab4712"
        }
    },
    {
        "id": "c3ba5a17-9281-4444-8f9a-2d3341cb0753",
        "type": "participantAdded",
        "sequenceId": "4",
        "versionId": "1",
        "content": {
            "message": "Participant Super Participant added",
            "participants": [
                {
                    "communicationIdentifier": {
                        "rawId": "8:acs:d9b2f18a-2c34-415e-889d-c210cb738186_c53e04a0-fc1f-46a2-953a-1ca4ccf02104"
                    },
                    "displayName": "Super Participant",
                    "shareHistoryTime": "2022-09-21T21:46:16.263+00:00"
                }
            ]
        },
        "senderDisplayName": null,
        "createdOn": "2022-09-22T18:29:26.4279074+00:00",
        "senderCommunicationIdentifier": {
            "rawId": "8:acs:d9b2f18a-2c34-415e-889d-c210cb738186_c41af59c-d6da-40bc-8b12-66c3b9ab4712"
        }
    }
]
```
