### PR TITLE
Make adding existing participant a no-op

### DIFF
--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
@@ -50,6 +50,12 @@ namespace AcsEmulatorAPI.Models
 					continue;
 				}
 
+				// Adding an existing participant again is a noop in the real chat service
+				if (Participants.Contains(participantToAdd))
+				{
+					continue;
+				}
+
 				var uct = new UserChatThread
 				{
 					User = participantToAdd,


### PR DESCRIPTION
Experimented with a real chat service and adding an existing participant again is a no-op.