### PR TITLE
Add basic SMS delivery reports via AzureEventGridSimulator

### DIFF
--- a/AcsEmulator/AcsEmulatorAPI/AcsEmulatorAPI.csproj
+++ b/AcsEmulator/AcsEmulatorAPI/AcsEmulatorAPI.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9" />
+    <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.9">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/AcsEmulator/AcsEmulatorAPI/EventPublisher.cs
+++ b/AcsEmulator/AcsEmulatorAPI/EventPublisher.cs
@@ -1,0 +1,65 @@
+﻿// Deprecated package, but works with EventGridSimulator.
+// TODO: Investigate why Azure.Messaging.EventGrid doesn't work.
+using Microsoft.Azure.EventGrid;
+using Microsoft.Azure.EventGrid.Models;
+
+namespace AcsEmulatorAPI
+{
+    public class EventPublisher
+    {
+        private readonly string _simulatorSystemTopicHostname;
+        private readonly bool _doEvents;
+
+        private EventGridClient _eventGridClient;
+
+        public EventPublisher(string simulatorSystemTopicHostname, string simulatorSystemTopicCredentials)
+        {
+            _simulatorSystemTopicHostname = simulatorSystemTopicHostname;
+
+            _doEvents = !string.IsNullOrEmpty(simulatorSystemTopicHostname) && !string.IsNullOrEmpty(simulatorSystemTopicCredentials);
+
+            if (_doEvents)
+            {
+                _eventGridClient = new EventGridClient(new TopicCredentials("TheLocal+DevelopmentKey="));
+            }
+        }
+
+        public async Task SendSmsDeliveryReport(string from, string to, string tag)
+        {
+            if (!_doEvents) return;
+
+            await _eventGridClient.PublishEventsWithHttpMessagesAsync(
+                topicHostname: _simulatorSystemTopicHostname,
+                events: new List<EventGridEvent>
+                {
+                    new EventGridEvent
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        //Topic = "/subscriptions/<my-sub-id>/resourceGroups/<my-rg-name>/providers/microsoft.communication/communicationservices/<my-resource-name>",
+                        Subject = $"/phonenumber/{from}",
+                        Data = new SmsDeliveryReport(
+                            Guid.NewGuid().ToString(),
+                            from,
+                            to,
+                            "Delivered",
+                            "2000: Message Delivered Successfully",
+                            DateTime.UtcNow,
+                            //deliveryAttempts: [Array],
+                            tag),
+                        EventType = "Microsoft.Communication.SMSDeliveryReportReceived",
+                        DataVersion = "1.0",
+                        EventTime = DateTime.UtcNow
+                    }
+                });
+        }
+
+        record SmsDeliveryReport(
+            string messageId,
+            string from,
+            string to,
+            string deliveryStatus,
+            string deliveryStatusDetails,
+            DateTime receivedTimeStamp,
+            string tag);
+    }
+}

--- a/AcsEmulator/AcsEmulatorAPI/Program.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Program.cs
@@ -49,6 +49,9 @@ builder.Services.AddSwaggerGen(options =>
 });
 
 builder.Services.AddSingleton(new Trouter());
+builder.Services.AddSingleton(new EventPublisher(
+	builder.Configuration["EventGridSimulatorSystemTopicHostname"],
+    builder.Configuration["EventGridSimulatorSystemTopicCredentials"]));
 
 var app = builder.Build();
 

--- a/AcsEmulator/AcsEmulatorAPI/Program.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Program.cs
@@ -53,7 +53,7 @@ builder.Services.AddSwaggerGen(options =>
 builder.Services.AddSingleton(new Trouter());
 builder.Services.AddSingleton(new EventPublisher(
 	builder.Configuration["EventGridSimulatorSystemTopicHostname"],
-    builder.Configuration["EventGridSimulatorSystemTopicCredentials"]));
+	builder.Configuration["EventGridSimulatorSystemTopicCredentials"]));
 
 var app = builder.Build();
 

--- a/AcsEmulator/AcsEmulatorAPI/Program.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Program.cs
@@ -5,6 +5,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.OpenApi.Models;
 
 var builder = WebApplication.CreateBuilder(args);
+builder.Logging.ClearProviders();
+builder.Logging.AddConsole();
 
 var connectionString = builder.Configuration.GetConnectionString("EmulatorDb");
 builder.Services.AddDbContext<AcsDbContext>(options => options

--- a/AcsEmulator/AcsEmulatorAPI/Sms.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Sms.cs
@@ -36,7 +36,7 @@ namespace AcsEmulatorAPI
                     m.To,
                     messageId = m.Id,
                     httpStatusCode = 202,
-                    successfull = true
+                    successful = true
                 });
 
                 return Results.Accepted(value: new

--- a/AcsEmulator/AcsEmulatorAPI/appsettings.json
+++ b/AcsEmulator/AcsEmulatorAPI/appsettings.json
@@ -4,6 +4,8 @@
   },
   "JwtSigningKey": "5fca297d-3350-45ad-a513-44a9d7d8fbfc",
   "ResourceId": "d9b2f18a-2c34-415e-889d-c210cb738186",
+  "EventGridSimulatorSystemTopicHostname": "localhost:60101",
+  "EventGridSimulatorSystemTopicCredentials": "TheLocal+DevelopmentKey=",
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
First version.

TODOs:

* Fork AzureEventGridSimulator and add API to programmatically set topic subscribers. Currently they need to be defined on startup via config/env vars
* Add ability to configure webhook URL via the AcsEmulator API and UI
* Add "respond-to" aka "Microsoft.Communication.SMSReceived" event
* Figure out how to nicely package both AcsEmulator and AzureEventGridSimulator together. Docker for now?

Pre-requisites in this version:
*  Start the [Sms event listener](https://github.com/DominikMe/acs-emulator/blob/main/TestClients/js/sms/src/listenSmsEvents.ts), by default it will listen on port 8080
```bash
cd .\TestClients\js\sms
npm run build
node .\dist\listenSmsEvents.js
```
*  Run https://github.com/pmcilreavy/AzureEventGridSimulator locally with _appsettings.json_ like this:
```json
{
  "topics": [
    {
      "name": "ATopicWithATestSubscriber",
      "port": 60101,
      "key": "TheLocal+DevelopmentKey=",
      "subscribers": [
        {
          "name": "MySmsEventListenerSubscription",
          "endpoint": "http://localhost:8080/webhook",
          "disableValidation": false
        }
      ]
    }
  ]
}
```

The ACS Emulator now has the following additional keys in its _appsettings.json_:
```json
"EventGridSimulatorSystemTopicHostname": "localhost:60101",
"EventGridSimulatorSystemTopicCredentials": "TheLocal+DevelopmentKey=",
```

Then run the [sendSmsWithOptions](https://github.com/DominikMe/acs-emulator/blob/main/TestClients/js/sms/src/sendSmsWithOptions.ts) sample app (which sets `enableDeliveryReport: true`) against the emulator.

You should see this output from _sendSmsWithOptions_:
```
PS C:\src\acs-emulator\TestClients\js\sms> node .\dist\sendSmsWithOptions.js
== Send SMS Message With Options ==
(node:29228) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
(Use `node --trace-warnings ...` to show where the warning was created)
Success:  {
  to: '+11234567890',
  messageId: '4af36e1e-3150-4832-a300-f504b4c9166c',
  httpStatusCode: 202,
  successful: true
}
== Done: Send SMS Message With Options ==
```

And something like this from _listenSmsEvents_:
```
PS C:\src\acs-emulator\TestClients\js\sms> node .\dist\listenSmsEvents.js
Listening on port 8080
Got callback. Body
[
  {
    id: 'eaa75b16-c0ab-444d-8c65-181bfb3d3858',
    subject: '',
    data: {
      validationCode: '686f6f6b-6562-2f77-3038-30383a74736f',
      validationUrl: 'https://192.168.1.1:60101/validate?id=686f6f6b-6562-2f77-3038-30383a74736f'
    },
    eventType: 'Microsoft.EventGrid.SubscriptionValidationEvent',
    eventTime: '2023-02-18T01:37:05.5329650Z',
    dataVersion: '1',
    metadataVersion: '1',
    topic: null
  }
]
Got SubscriptionValidation event data, validation code: 686f6f6b-6562-2f77-3038-30383a74736f topic: null
Got callback. Body
[
  {
    id: 'c6009473-0326-4a0e-9c8c-a7c3a5966a68',
    subject: '/phonenumber/+18001110000',
    data: {
      messageId: '30f74261-eed7-41c1-87aa-1a5fb9735ad8',
      from: '+18001110000',
      to: '+11234567890',
      deliveryStatus: 'Delivered',
      deliveryStatusDetails: '2000: Message Delivered Successfully',
      receivedTimeStamp: '2023-02-18T01:37:53.0554109Z',
      tag: 'marketing'
    },
    eventType: 'Microsoft.Communication.SMSDeliveryReportReceived',
    eventTime: '2023-02-18T01:37:53.0555862Z',
    dataVersion: '1.0',
    metadataVersion: '1',
    topic: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/eventGridSimulator/providers/Microsoft.EventGrid/topics/ATopicWithATestSubscriber'
  }
]
Got delivery reoport event data, report details:
{
  from: '+18001110000',
  to: '+11234567890',
  deliveryStatus: 'Delivered',
  deliveryStatusDetails: '2000: Message Delivered Successfully',
  tag: 'marketing'
}
```