### PR TITLE
Add UI for responding to SMS messages and generating new "incoming SMS" events

### DIFF
--- a/AcsEmulator/acs-emulator-ui/src/components/NewIncomingSmsMessage.tsx
+++ b/AcsEmulator/acs-emulator-ui/src/components/NewIncomingSmsMessage.tsx
@@ -1,0 +1,14 @@
+export interface NewIncomingSmsMessageProps {
+  from: string,
+  to: string
+}
+
+export const NewIncomingSmsMessage = (props: NewIncomingSmsMessageProps) => {
+
+  return (
+    <div>
+      <span>From:</span><span>{props.from}</span>
+      <span>To:</span><span>{props.to}</span>
+    </div>
+  );
+}

--- a/AcsEmulator/acs-emulator-ui/src/components/NewIncomingSmsMessage.tsx
+++ b/AcsEmulator/acs-emulator-ui/src/components/NewIncomingSmsMessage.tsx
@@ -1,14 +1,67 @@
+import { useState } from 'react';
+
+import {
+  DefaultButton,
+  PrimaryButton,
+  Stack,
+  TextField
+} from '@fluentui/react';
+
+import { raiseSmsReceivedEvent } from '../services/sms';
+
 export interface NewIncomingSmsMessageProps {
   from: string,
-  to: string
+  to: string,
+  onClosed(): void
 }
 
 export const NewIncomingSmsMessage = (props: NewIncomingSmsMessageProps) => {
+  const [from, setFrom] = useState<string>(props.from);
+  const [to, setTo] = useState<string>(props.to);
+  const [message, setMessage] = useState<string>('');
+
+  const onFromChanged = (_event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+    if (newValue) {
+      setFrom(newValue);
+    } else {
+      setFrom('');
+    }
+  }
+
+  const onToChanged = (_event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+    if (newValue) {
+      setTo(newValue);
+    } else {
+      setTo('');
+    }
+  }
+
+  const onMessageChanged = (_event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
+    if (newValue) {
+      setMessage(newValue);
+    } else {
+      setMessage('');
+    }
+  }
+
+  const onSendClicked = async () => {
+    await raiseSmsReceivedEvent(from, to, message);
+    props.onClosed();
+  }
+
+  const onCancelClicked = () => {
+    props.onClosed();
+  }
 
   return (
-    <div>
-      <span>From:</span><span>{props.from}</span>
-      <span>To:</span><span>{props.to}</span>
-    </div>
+    <Stack tokens={{childrenGap: 15}}>
+      <TextField label='From' defaultValue={from} onChange={onFromChanged} />
+      <TextField label='To' defaultValue={to} onChange={onToChanged} />
+      <TextField label='Message' multiline defaultValue={message} onChange={onMessageChanged} />
+      <Stack horizontal tokens={{childrenGap: 15}}>
+        <PrimaryButton text='Send' onClick={onSendClicked} />
+        <DefaultButton text='Cancel' onClick={onCancelClicked} />
+      </Stack>
+    </Stack>
   );
 }

--- a/AcsEmulator/acs-emulator-ui/src/components/SmsMessages.tsx
+++ b/AcsEmulator/acs-emulator-ui/src/components/SmsMessages.tsx
@@ -147,6 +147,7 @@ export const SmsMessages = () => {
           <NewIncomingSmsMessage
             from={newMessageFrom}
             to={newMessageTo}
+            onClosed={() => setNewIncomingMessageBoxVisible(false)}
           />
         </div>
       </Modal>

--- a/AcsEmulator/acs-emulator-ui/src/components/SmsMessages.tsx
+++ b/AcsEmulator/acs-emulator-ui/src/components/SmsMessages.tsx
@@ -59,8 +59,9 @@ export const SmsMessages = () => {
 
   const replyButtonClicked = (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
     if (selectedItem) {
-      setNewMessageFrom(selectedItem?.from);
-      setNewMessageTo(selectedItem?.to);
+      // Note - "from" and "to" are reversed - we are creating a fake _response_  to the original message
+      setNewMessageFrom(selectedItem?.to);
+      setNewMessageTo(selectedItem?.from);
       setNewIncomingMessageBoxVisible(true);
     }
   }

--- a/AcsEmulator/acs-emulator-ui/src/components/SmsMessages.tsx
+++ b/AcsEmulator/acs-emulator-ui/src/components/SmsMessages.tsx
@@ -6,12 +6,22 @@ import {
   ICommandBarItemProps,
   IColumn,
   ShimmeredDetailsList,
-  SelectionMode
+  SelectionMode,
+  Selection
 } from '@fluentui/react';
 import { SmsMessage, getAll as getAllSmsMessages } from '../services/sms';
 
 export const SmsMessages = () => {
   const [loadedSmsMessages, setLoadedSmsMessages] = useState<SmsMessage[] | undefined>(undefined);
+  const [selectedItem, setSelectedItem] = useState<object>();
+
+  const selection = new Selection({
+    onSelectionChanged: () => {
+      console.log('handle selection change',selection.getSelection())
+      setSelectedItem(selection.getSelection()[0]);
+    },
+    selectionMode: SelectionMode.single
+  });
 
   const stackTokens: IStackTokens = {
     childrenGap: 5,
@@ -86,7 +96,8 @@ export const SmsMessages = () => {
         items={loadedSmsMessages || []}
         enableShimmer={!loadedSmsMessages}
         columns={columns}
-        selectionMode={SelectionMode.none}
+        selectionMode={SelectionMode.single}
+        selection={selection}
       />
     </Stack>
   );

--- a/AcsEmulator/acs-emulator-ui/src/services/sms.ts
+++ b/AcsEmulator/acs-emulator-ui/src/services/sms.ts
@@ -26,3 +26,19 @@ export const getAll = async (): Promise<SmsMessage[]>  => {
 
   return messages;
 }
+
+export const raiseSmsReceivedEvent = async (from: string, to: string, message: string): Promise<void> => {
+  const data = {
+    from: from,
+    to: to,
+    message: message
+  }
+
+  await fetch('/admin/sms:raiseSmsReceivedEvent', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(data)
+  });
+}


### PR DESCRIPTION
Can now do this:
![image](https://user-images.githubusercontent.com/46465618/220199261-5a2ef766-4fe5-4fa6-b07a-de1a074591e3.png)

Which will create the "EventGrid" event:
```javascript
[
  {
    id: '0eed01c6-55db-4b25-a762-7a661cc5b0b9',
    subject: '/phonenumber/+18001110000',
    data: {
      messageId: 'f3abde5f-7b0e-4221-a792-774ef67c7cbe',
      from: '+11234567894',
      to: '+18001110000',
      message: 'World, hello!',
      receivedTimeStamp: '2023-02-20T21:13:38.7440267Z'
    },
    eventType: 'Microsoft.Communication.SMSReceived',
    eventTime: '2023-02-20T21:13:38.7440886Z',
    dataVersion: '1.0',
    metadataVersion: '1',
    topic: '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/eventGridSimulator/providers/Microsoft.EventGrid/topics/ATopicWithATestSubscriber'
  }
]
```