### PR TITLE
Migrate out of deprecated Microsoft.Azure.EventGrid

### DIFF
--- a/AcsEmulator/AcsEmulatorAPI/AcsEmulatorAPI.csproj
+++ b/AcsEmulator/AcsEmulatorAPI/AcsEmulatorAPI.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="ACSEmulatorAPI.Tests" />
-    <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.1" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.23.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />

--- a/AcsEmulator/AcsEmulatorAPI/appsettings.json
+++ b/AcsEmulator/AcsEmulatorAPI/appsettings.json
@@ -4,7 +4,7 @@
   },
   "JwtSigningKey": "5fca297d-3350-45ad-a513-44a9d7d8fbfc",
   "ResourceId": "d9b2f18a-2c34-415e-889d-c210cb738186",
-  "EventGridSimulatorSystemTopicHostname": "localhost:60101",
+  "EventGridSimulatorSystemTopicHostname": "https://localhost:60101/api/events",
   "EventGridSimulatorSystemTopicCredentials": "TheLocal+DevelopmentKey=",
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
Azure.Messaging.EventGrid is Deprecated and Nuget was warning about security vulnerabilities of transient dependencies

Updated it following guidelines from:
https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/eventgrid/Azure.Messaging.EventGrid/MigrationGuide.md

Tested that it works as before and EventGrid emulator receives events on same previous Topic