### PR TITLE
Add OpenTelemetry instrumentation

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Setup .NET
-      uses: actions/setup-dotnet@v3
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.x
     - name: Create Certificate

--- a/AcsEmulator/AcsEmulatorAPI.Tests/IdentityServiceTests.cs
+++ b/AcsEmulator/AcsEmulatorAPI.Tests/IdentityServiceTests.cs
@@ -26,7 +26,7 @@ namespace AcsEmulatorAPI
             var client = _factory.CreateClient();
 
             var response = client.PostAsJsonAsync("/identities/", new CreateIdentityRequest([IdentityTokenScope.Chat])).Result;
-            Console.WriteLine(response);
+            //Console.WriteLine(response);
             Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             var location = response.Headers.Location;
             Assert.IsNotNull(location);

--- a/AcsEmulator/AcsEmulatorAPI/AcsEmulatorAPI.csproj
+++ b/AcsEmulator/AcsEmulatorAPI/AcsEmulatorAPI.csproj
@@ -8,6 +8,12 @@
   <ItemGroup>
     <InternalsVisibleTo Include="ACSEmulatorAPI.Tests" />
     <PackageReference Include="Azure.Messaging.EventGrid" Version="4.23.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.7.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.7.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.7.0-beta.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.4.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />

--- a/AcsEmulator/AcsEmulatorAPI/CallAutomationWebSockets.cs
+++ b/AcsEmulator/AcsEmulatorAPI/CallAutomationWebSockets.cs
@@ -18,7 +18,7 @@ namespace AcsEmulatorAPI
 				using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
 				_sockets.Add(phoneNumber, webSocket);
 
-				await Listen(webSocket, phoneNumber,log);
+				await Listen(webSocket, phoneNumber, log);
                 _sockets.Remove(phoneNumber);
 
 				return Results.Ok();

--- a/AcsEmulator/AcsEmulatorAPI/CallAutomationWebSockets.cs
+++ b/AcsEmulator/AcsEmulatorAPI/CallAutomationWebSockets.cs
@@ -10,7 +10,7 @@ namespace AcsEmulatorAPI
 
 		public void AddEndpoints(WebApplication app)
 		{
-			app.MapGet("/admin/callAutomation/sockets/{phoneNumber}", async (HttpContext context, string phoneNumber) =>
+			app.MapGet("/admin/callAutomation/sockets/{phoneNumber}", async (HttpContext context, string phoneNumber, ILogger<Program> log) =>
 			{
 				if (!context.WebSockets.IsWebSocketRequest)
 					return Results.BadRequest();
@@ -18,7 +18,7 @@ namespace AcsEmulatorAPI
 				using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
 				_sockets.Add(phoneNumber, webSocket);
 
-				await Listen(webSocket, phoneNumber);
+				await Listen(webSocket, phoneNumber,log);
                 _sockets.Remove(phoneNumber);
 
 				return Results.Ok();
@@ -39,16 +39,16 @@ namespace AcsEmulatorAPI
             });
         }
 
-        public async Task AnswerPhoneCall(string phoneNumber, string callerId) => await SendMessage(phoneNumber, callerId, JsonSerializer.Serialize(
+        public async Task AnswerPhoneCall(string phoneNumber, string callerId, ILogger<Program> log) => await SendMessage(phoneNumber, callerId, JsonSerializer.Serialize(
                     new
                     {
                         action = "answer",
                         time = DateTimeOffset.UtcNow.ToString("o"),
                         callerId,
                     }
-                ));
+                ), log);
 
-        public async Task PlayText(string phoneNumber, string callerId, string text) => await SendMessage(phoneNumber, callerId, JsonSerializer.Serialize(
+        public async Task PlayText(string phoneNumber, string callerId, string text, ILogger<Program> log) => await SendMessage(phoneNumber, callerId, JsonSerializer.Serialize(
                     new
                     {
                         action = "playText",
@@ -56,15 +56,15 @@ namespace AcsEmulatorAPI
                         callerId,
 						text
                     }
-                ));
+                ), log);
 
-        private async Task SendMessage(string phoneNumber, string callerId, string message)
+        private async Task SendMessage(string phoneNumber, string callerId, string message, ILogger<Program> log)
 		{
             if (_sockets.TryGetValue(phoneNumber, out var socket))
             {
                 await SendMessage(socket, message);
             }
-            Console.WriteLine("Failed to get active websocket for " + phoneNumber);
+            log.LogError("Failed to get active websocket for " + phoneNumber);
         }
 
         private static Task SendMessage(WebSocket webSocket, string message)
@@ -74,7 +74,7 @@ namespace AcsEmulatorAPI
 					true,
 					CancellationToken.None);
 
-		private async Task Listen(WebSocket webSocket, string phoneNumber)
+		private async Task Listen(WebSocket webSocket, string phoneNumber, ILogger<Program> log)
 		{
 			var buffer = new byte[1024 * 4];
 			var receiveResult = await webSocket.ReceiveAsync(
@@ -85,7 +85,7 @@ namespace AcsEmulatorAPI
 				var received = Encoding.UTF8.GetString(buffer);
 
 				// todo: handle
-				Console.WriteLine($"{phoneNumber} sent: {received}");
+				log.LogInformation($"{phoneNumber} sent: {received}");
 
 				Array.Clear(buffer, 0, buffer.Length);
 				receiveResult = await webSocket.ReceiveAsync(

--- a/AcsEmulator/AcsEmulatorAPI/Program.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Program.cs
@@ -85,7 +85,7 @@ otel.WithTracing(tracing =>
 	tracing.AddSqlClientInstrumentation(
         options => options.SetDbStatementForText = true
 		);
-    if (tracingOtlpEndpoint is not null && tracingOtlpEndpoint != "")
+    if (!string.IsNullOrEmpty(tracingOtlpEndpoint))
     {
         tracing.AddOtlpExporter(otlpOptions =>
         {

--- a/AcsEmulator/AcsEmulatorAPI/Sms.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Sms.cs
@@ -46,6 +46,8 @@ namespace AcsEmulatorAPI
                     successful = true
                 });
 
+                log.LogInformation("Number of SMS sent: {0}", messages.Count());
+
                 return Results.Accepted(value: new
                 {
                     value = messages

--- a/AcsEmulator/AcsEmulatorAPI/Trouter.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Trouter.cs
@@ -119,7 +119,7 @@ namespace AcsEmulatorAPI
 			app.MapGet("/trouter/f/{sessionId}", () => Results.Ok());
 		}
 
-		public async Task SendChatMessageReceived(string receiverRawId, string threadId, ChatMessage message)
+		public async Task SendChatMessageReceived(string receiverRawId, string threadId, ChatMessage message, ILogger<Program> log)
 		{
 			if(_skypeIdToSockets.TryGetValue(receiverRawId, out var sockets))
 			{
@@ -158,10 +158,10 @@ namespace AcsEmulatorAPI
 					));
 				}
 			}
-			Console.WriteLine("Failed to get active websocket for " + receiverRawId);
+            log.LogError("Failed to get active websocket for " + receiverRawId);
 		}
 
-		public async Task SendTyping(string senderRawId, string? senderDisplayName, string receiverRawId, string threadId, string messageId)
+		public async Task SendTyping(string senderRawId, string? senderDisplayName, string receiverRawId, string threadId, string messageId, ILogger<Program> log)
 		{
 			if (_skypeIdToSockets.TryGetValue(receiverRawId, out var sockets))
 			{
@@ -193,7 +193,7 @@ namespace AcsEmulatorAPI
 					));
 				}
 			}
-			Console.WriteLine("Failed to get active websocket for " + receiverRawId);
+			log.LogError("Failed to get active websocket for " + receiverRawId);
 		}
 
 		private JwtSecurityToken? ValidateToken(string token, string jwtSigningKey)

--- a/AcsEmulator/AcsEmulatorAPI/Trouter.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Trouter.cs
@@ -158,7 +158,7 @@ namespace AcsEmulatorAPI
 					));
 				}
 			}
-            log.LogError("Failed to get active websocket for " + receiverRawId);
+			log.LogError("Failed to get active websocket for " + receiverRawId);
 		}
 
 		public async Task SendTyping(string senderRawId, string? senderDisplayName, string receiverRawId, string threadId, string messageId, ILogger<Program> log)

--- a/AcsEmulator/AcsEmulatorAPI/appsettings.json
+++ b/AcsEmulator/AcsEmulatorAPI/appsettings.json
@@ -6,10 +6,11 @@
   "ResourceId": "d9b2f18a-2c34-415e-889d-c210cb738186",
   "EventGridSimulatorSystemTopicHostname": "https://localhost:60101/api/events",
   "EventGridSimulatorSystemTopicCredentials": "TheLocal+DevelopmentKey=",
+  "OpenTelemetryEndpointUrl": null,
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Information"
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
Add OpenTelemetry instrumentation with optional endpoint (to connect Jaeger)

It is handy to know which Http endpoints are hit and also the text of the SQL queries executed by direct instrumentation part of ASP.NET and Entities framework