### PR TITLE
Add Unit tests for ChatController and Chat Threads

### DIFF
--- a/AcsEmulator/AcsEmulatorAPI.Tests/ChatControllerTests.cs
+++ b/AcsEmulator/AcsEmulatorAPI.Tests/ChatControllerTests.cs
@@ -1,0 +1,75 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AcsEmulatorAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using System.Net.Http.Json;
+using AcsEmulatorAPI.Models;
+
+namespace AcsEmulatorAPI.Tests
+{
+    [TestClass()]
+    public class ChatControllerTests
+    {
+        private readonly WebApplicationFactory<Program> _factory;
+        private readonly HttpClient _client;
+        private readonly string _authToken;
+
+        public ChatControllerTests()
+        {
+            _factory = new WebApplicationFactory<Program>();
+            _client = _factory.CreateClient();
+            // If Identity Unit tests is passing, below code will work
+            var identity = _client.PostAsJsonAsync("/identities/", new CreateIdentityRequest([IdentityTokenScope.Chat])).Result;
+            var token = _client.PostAsJsonAsync(identity.Headers.Location + "/:issueAccessToken", new IssueTokenRequest([IdentityTokenScope.Chat], 60)).Result;
+            var tokenResponse = token.Content.ReadFromJsonAsync<IdentityTokenResponse>().Result;
+            Assert.IsNotNull(tokenResponse);
+            _authToken = tokenResponse.token;    
+        }
+
+        [TestMethod()]
+        public void AddChatEndpointsTest()
+        {
+            // Check if the /chat/threads endpoint is protected
+            var response = _client.PostAsJsonAsync("/chat/threads", new CreateChatThreadRequest("Test Topic", new List<ChatParticipant>())).Result;
+            Assert.AreEqual(System.Net.HttpStatusCode.Unauthorized, response.StatusCode);
+
+            // Add default Authorize header
+            _client.DefaultRequestHeaders.Add("Authorization", "Bearer " + _authToken);
+
+            // Create a New chat thread
+            response = _client.PostAsJsonAsync("/chat/threads", new CreateChatThreadRequest("Test Topic", new List<ChatParticipant>())).Result;
+            Assert.AreEqual(System.Net.HttpStatusCode.Created, response.StatusCode);
+
+            Console.WriteLine(response.Content.ReadAsStringAsync().Result);
+            var chatThreadCreation = response.Content.ReadFromJsonAsync<ChatThreadCreation>().Result;
+            Assert.IsNotNull(chatThreadCreation);
+            var chatThreadInfo = chatThreadCreation.ChatThread;
+            // id must start with 19:
+            Assert.IsTrue(chatThreadInfo.Id.StartsWith("19:"));
+            Assert.AreEqual("Test Topic", chatThreadInfo.Topic);
+
+
+            // Call Get /chat/threads
+            var chatThreads = _client.GetFromJsonAsync<ChatThreadInfo>("/chat/threads").Result;
+            Assert.IsNotNull(chatThreads);
+            var firstChatThread = chatThreads.Value.First();
+            Assert.AreEqual(chatThreadInfo.Id, firstChatThread.Id);
+            Assert.AreEqual(chatThreadInfo.Topic, firstChatThread.Topic);
+
+            // Call Get /chat/threads/{chatThreadInfo.Id}
+            var chatThread = _client.GetFromJsonAsync<ChatThreadCreationInfo>($"/chat/threads/{chatThreadInfo.Id}").Result;
+            Assert.IsNotNull(chatThread);
+            Assert.AreEqual(chatThreadInfo.Id, chatThread.Id);
+
+            // Test the Get on admin chat endpoint
+            var adminChatThreads = _client.GetFromJsonAsync<ChatThreadInfo>("/admin/chat/threads").Result;
+            Assert.IsNotNull(adminChatThreads);
+            // Admin chat thread can show more info depending on DB, look for the specific Id
+            Assert.IsTrue(adminChatThreads.Value.Any(x => x.Id == chatThreadInfo.Id));
+        }
+    }
+}

--- a/AcsEmulator/AcsEmulatorAPI.Tests/ChatThreadControllerTests.cs
+++ b/AcsEmulator/AcsEmulatorAPI.Tests/ChatThreadControllerTests.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using AcsEmulatorAPI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Testing;
+using AcsEmulatorAPI.Models;
+using System.Net.Http.Json;
+using System.Reflection.PortableExecutable;
+
+namespace AcsEmulatorAPI.Tests
+{
+    [TestClass()]
+    public class ChatThreadControllerTests
+    {
+        private readonly WebApplicationFactory<Program> _factory;
+        private readonly HttpClient _client;
+        private ChatThreadCreationInfo _chatThreadCreationInfo;
+        
+        public ChatThreadControllerTests()
+        {
+            _factory = new WebApplicationFactory<Program>();
+            _client = _factory.CreateClient();
+            // If Identity And ChatController Unit tests are passing, below code will work
+            var identity1 = _client.PostAsJsonAsync("/identities/", new CreateIdentityRequest([IdentityTokenScope.Chat])).Result;
+            var token = _client.PostAsJsonAsync(identity1.Headers.Location + "/:issueAccessToken", new IssueTokenRequest([IdentityTokenScope.Chat], 60)).Result;
+            var tokenResponse = token.Content.ReadFromJsonAsync<IdentityTokenResponse>().Result;
+            Assert.IsNotNull(tokenResponse);
+            _client.DefaultRequestHeaders.Add("Authorization", "Bearer " + tokenResponse.token);
+            // Create a New chat thread
+            var chatThread = _client.PostAsJsonAsync("/chat/threads", new CreateChatThreadRequest("Test Topic", new List<ChatParticipant>())).Result;
+            Assert.IsNotNull(chatThread);
+            var chatThreadInfo = chatThread.Content.ReadFromJsonAsync<ChatThreadCreation>().Result;
+            Assert.IsNotNull(chatThreadInfo);
+            _chatThreadCreationInfo = chatThreadInfo.ChatThread;
+        }
+
+        [TestMethod()]
+        public void AddChatThreadEndpointsTest()
+        {
+            var identity2 = _client.PostAsJsonAsync("/identities/", new CreateIdentityRequest([IdentityTokenScope.Chat])).Result;
+            // Get everything right of /identities/ prefix from the location
+            var identity2Str = identity2.Headers.Location?.ToString().Split("/identities/")[1];
+            Assert.IsNotNull(identity2Str);
+
+            var participant2 = new ChatParticipant(
+                new CommunicationIdentifier(identity2Str), "John Doe", DateTimeOffset.UtcNow);
+
+            // Call add participant to chat thread
+            var addParticipant = _client.PostAsJsonAsync($"/chat/threads/{_chatThreadCreationInfo.Id}/participants/:add",
+                                  new AddChatParticipantsRequest([participant2])).Result;
+            Assert.AreEqual(System.Net.HttpStatusCode.Created, addParticipant.StatusCode);
+            // Get Participants
+
+            var getParticipants = _client.GetFromJsonAsync<ChatParticipantsInfo>($"/chat/threads/{_chatThreadCreationInfo.Id}/participants").Result;
+            Assert.IsNotNull(getParticipants);
+            // Assert there is 2 participants:
+            Assert.IsTrue(getParticipants.Value.Count == 2);
+            // Assert any of the participants is the one we added
+            Assert.IsTrue(getParticipants.Value.Any(x => x.CommunicationIdentifier.RawId == identity2Str));
+
+
+            // Sends a Message
+            var message = _client.PostAsJsonAsync($"/chat/threads/{_chatThreadCreationInfo.Id}/messages",
+                               new SendChatMessageRequest("Hello World", "John Doe", ChatMessageType.Text)).Result;
+            Assert.AreEqual(System.Net.HttpStatusCode.Created, message.StatusCode);
+
+            // Get Messages
+            //var getMessages = _client.GetFromJsonAsync<ChatMessagesResponse>($"/chat/threads/{_chatThreadCreationInfo.Id}/messages").Result;
+            var getMessages = _client.GetStringAsync($"/chat/threads/{_chatThreadCreationInfo.Id}/messages").Result;
+            Assert.IsNotNull(getMessages);
+            Console.WriteLine(getMessages);
+
+
+
+        }
+    }
+}

--- a/AcsEmulator/AcsEmulatorAPI.Tests/ChatThreadControllerTests.cs
+++ b/AcsEmulator/AcsEmulatorAPI.Tests/ChatThreadControllerTests.cs
@@ -61,20 +61,16 @@ namespace AcsEmulatorAPI.Tests
             // Assert any of the participants is the one we added
             Assert.IsTrue(getParticipants.Value.Any(x => x.CommunicationIdentifier.RawId == identity2Str));
 
-
             // Sends a Message
             var message = _client.PostAsJsonAsync($"/chat/threads/{_chatThreadCreationInfo.Id}/messages",
                                new SendChatMessageRequest("Hello World", "John Doe", ChatMessageType.Text)).Result;
             Assert.AreEqual(System.Net.HttpStatusCode.Created, message.StatusCode);
 
             // Get Messages
-            //var getMessages = _client.GetFromJsonAsync<ChatMessagesResponse>($"/chat/threads/{_chatThreadCreationInfo.Id}/messages").Result;
             var getMessages = _client.GetStringAsync($"/chat/threads/{_chatThreadCreationInfo.Id}/messages").Result;
             Assert.IsNotNull(getMessages);
-            Console.WriteLine(getMessages);
-
-
-
+            Assert.IsTrue(getMessages.Contains("Hello World"));
+            
         }
     }
 }

--- a/AcsEmulator/AcsEmulatorAPI.Tests/IdentityServiceTests.cs
+++ b/AcsEmulator/AcsEmulatorAPI.Tests/IdentityServiceTests.cs
@@ -5,7 +5,7 @@ using System.Net.Http.Json;
 
 
 
-namespace AcsEmulatorAPI
+namespace AcsEmulatorAPI.Tests
 {
     [TestClass()]
     public class IdentityServiceTests
@@ -16,7 +16,6 @@ namespace AcsEmulatorAPI
             _factory = new WebApplicationFactory<Program>();
         }
 
-        record TokenResponse(string token, string expiresOn);
 
         // Since identities are stateful, this is more an end-to-end test than an unit one.
         // Having a class to represent identities and extract code outside of route mapping would help
@@ -37,7 +36,7 @@ namespace AcsEmulatorAPI
             var token = client.PostAsJsonAsync(location + "/:issueAccessToken", new IssueTokenRequest([IdentityTokenScope.Chat], 60)).Result;
             Assert.AreEqual(HttpStatusCode.OK, token.StatusCode);
             //Console.WriteLine(token.Content.ReadAsStringAsync().Result);
-            TokenResponse? tokenResponse = token.Content.ReadFromJsonAsync<TokenResponse>().Result;
+            IdentityTokenResponse? tokenResponse = token.Content.ReadFromJsonAsync<IdentityTokenResponse>().Result;
 
             Assert.IsNotNull(tokenResponse);
             // Token should be a long string

--- a/AcsEmulator/AcsEmulatorAPI/ChatThreadController.cs
+++ b/AcsEmulator/AcsEmulatorAPI/ChatThreadController.cs
@@ -111,7 +111,7 @@ namespace AcsEmulatorAPI
 							Sender = thisUser,
 							SenderDisplayName = req.SenderDisplayName,
 							Type = req.Type ?? ChatMessageType.Text,
-							SequenceId = nextSequenceId
+							SequenceId = nextSequenceId.ToString()
 						};
 						thisThread.Messages.Add(msg);
 
@@ -165,8 +165,8 @@ namespace AcsEmulatorAPI
 
 								sequenceId = m.SequenceId.ToString(),
 
-								// TODO
-								versionId = "1",
+								// Now versionId is gotten from Db, fallback to "1"
+								versionId = m.VersionId ?? "1",
 
 								content = new
 								{

--- a/AcsEmulator/AcsEmulatorAPI/EventPublisher.cs
+++ b/AcsEmulator/AcsEmulatorAPI/EventPublisher.cs
@@ -1,6 +1,4 @@
-﻿// Deprecated package, but works with EventGridSimulator.
-// TODO: Investigate why Azure.Messaging.EventGrid doesn't work.
-using Azure;
+﻿using Azure;
 using Azure.Messaging.EventGrid;
 using System.Text;
 

--- a/AcsEmulator/AcsEmulatorAPI/Migrations/20240312210807_ChangeChatSchema.Designer.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Migrations/20240312210807_ChangeChatSchema.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using AcsEmulatorAPI.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace AcsEmulatorAPI.Migrations
 {
     [DbContext(typeof(AcsDbContext))]
-    partial class AcsDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240312210807_ChangeChatSchema")]
+    partial class ChangeChatSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/AcsEmulator/AcsEmulatorAPI/Migrations/20240312210807_ChangeChatSchema.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Migrations/20240312210807_ChangeChatSchema.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace AcsEmulatorAPI.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeChatSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SequenceId",
+                table: "ChatMessages",
+                type: "TEXT",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.AddColumn<string>(
+                name: "VersionId",
+                table: "ChatMessages",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "VersionId",
+                table: "ChatMessages");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "SequenceId",
+                table: "ChatMessages",
+                type: "INTEGER",
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "TEXT");
+        }
+    }
+}

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatMessage.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatMessage.cs
@@ -1,8 +1,9 @@
 ﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace AcsEmulatorAPI.Models
 {
-	//[Table("ChatMessages")]
+	[Table("ChatMessages")]
 	public class ChatMessage
 	{
 		public Guid Id { get; set; }
@@ -17,10 +18,13 @@ namespace AcsEmulatorAPI.Models
 
 		public DateTimeOffset CreatedOn { get; set; } = DateTimeOffset.UtcNow;
 
-		public int SequenceId { get; set; }
+		// SequenceId is sent as String in (/chat/threads/{thread_id}/messages)
+        public string SequenceId { get; set; }
+
+		public string? VersionId { get; set; }
 	}
 
-	//[Table("AddParticipantsChatMessages")]
+	[Table("AddParticipantsChatMessages")]
 	public class AddParticipantsChatMessage: ChatMessage
 	{
 		public virtual ICollection<AddedParticipant> AddedParticipants { get; set; }
@@ -36,4 +40,10 @@ namespace AcsEmulatorAPI.Models
 
 		public DateTimeOffset? ShareHistoryTime { get; set; }
 	}
+
+
+	// ChatMessage in Payload do not match above record ( SequenceId is string, and many other fields are missing)
+	// Creating another one, but will need to be merged
+    // Response of /chat/threads/{thread_id}/messages GET
+	public record ChatMessagesResponse(List<ChatMessage> Value);
 }

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatMessage.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatMessage.cs
@@ -19,7 +19,7 @@ namespace AcsEmulatorAPI.Models
 		public DateTimeOffset CreatedOn { get; set; } = DateTimeOffset.UtcNow;
 
 		// SequenceId is sent as String in (/chat/threads/{thread_id}/messages)
-        public string SequenceId { get; set; }
+		public string SequenceId { get; set; }
 
 		public string? VersionId { get; set; }
 	}

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatMessage.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatMessage.cs
@@ -24,7 +24,7 @@ namespace AcsEmulatorAPI.Models
 		public string? VersionId { get; set; }
 	}
 
-	[Table("AddParticipantsChatMessages")]
+	//[Table("AddParticipantsChatMessages")]
 	public class AddParticipantsChatMessage: ChatMessage
 	{
 		public virtual ICollection<AddedParticipant> AddedParticipants { get; set; }
@@ -41,9 +41,4 @@ namespace AcsEmulatorAPI.Models
 		public DateTimeOffset? ShareHistoryTime { get; set; }
 	}
 
-
-	// ChatMessage in Payload do not match above record ( SequenceId is string, and many other fields are missing)
-	// Creating another one, but will need to be merged
-    // Response of /chat/threads/{thread_id}/messages GET
-	public record ChatMessagesResponse(List<ChatMessage> Value);
 }

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatModels.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatModels.cs
@@ -1,4 +1,7 @@
-﻿namespace AcsEmulatorAPI.Models
+﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
+
+namespace AcsEmulatorAPI.Models
 {
 	public class CommunicationIdentifier
 	{
@@ -21,14 +24,20 @@
 
 	public record AddChatParticipantsRequest(List<ChatParticipant> Participants);
 
-	public enum ChatMessageType
+    [JsonConverter(typeof(JsonStringEnumConverter))]
+    public enum ChatMessageType
 	{
-		Text,
-		Html,
-		TopicUpdated,
-		ParticipantAdded,
-		ParticipantRemoved
-	}
+        [EnumMember(Value = "text")]
+        Text,
+        [EnumMember(Value = "html")]
+        Html,
+        [EnumMember(Value = "topicUpdated")]
+        TopicUpdated,
+        [EnumMember(Value = "participantAdded")]
+        ParticipantAdded,
+        [EnumMember(Value = "participantRemoved")]
+        ParticipantRemoved
+    }
 
 	public record SendChatMessageRequest(
 		string Content,
@@ -36,4 +45,18 @@
 		ChatMessageType? Type);
 
 	public record TypingRequest(string? SenderDisplayName);
+
+	// Response of /chat/threads POST
+	public record ChatThreadCreation(ChatThreadCreationInfo ChatThread);
+	public record ChatThreadCreationInfo(
+		string Id,
+		string Topic,
+		DateTimeOffset? CreatedOn,
+		CommunicationIdentifier? CreatedByCommunicationIdentifier);
+
+	// Response of /chat/threads GET
+	public record ChatThreadInfo(List<ChatThreadCreationInfo> Value);
+
+	// Response of /chat/threads/{chatThreadId}/participants GET
+	public record ChatParticipantsInfo(List<ChatParticipant> Value);
 }

--- a/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/ChatThread.cs
@@ -74,7 +74,7 @@ namespace AcsEmulatorAPI.Models
 
 					Sender = initiator,
 					Type = ChatMessageType.ParticipantAdded,
-					SequenceId = nextSequenceId,
+					SequenceId = nextSequenceId.ToString(),
 
 					AddedParticipants = new List<AddedParticipant>
 					{
@@ -86,7 +86,8 @@ namespace AcsEmulatorAPI.Models
 							ShareHistoryTime = requestParticipant.ShareHistoryTime,
 							DisplayName = requestParticipant.DisplayName
 						}
-					}
+					},
+					VersionId = "1"
 				};
 				Messages.Add(apm);
 

--- a/AcsEmulator/AcsEmulatorAPI/Models/IdentityModels.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Models/IdentityModels.cs
@@ -24,4 +24,8 @@ namespace AcsEmulatorAPI.Models
 
     record IssueTokenRequest(IdentityTokenScope[] scopes, int? expiresInMinutes);
 
+    // Response Type of /identity/{id}/:issueAccessToken
+    record IdentityTokenResponse(string token, string expiresOn);
+
+
 }

--- a/AcsEmulator/AcsEmulatorAPI/Program.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Program.cs
@@ -2,7 +2,6 @@ using AcsEmulatorAPI;
 using AcsEmulatorAPI.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi.Models;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;


### PR DESCRIPTION
Added unit tests to cover Chat to prepare for Event sending.

* Tried also to unify the DB schema with the HTTP Rest protocol 
( same data types, added VersionId to the DB since Chat message version is part of the protocol)

* Used EF to generate the migration.
* Tested with UI Lib Chat composite that nothing is broken


