### PR TITLE
Get Call API in Call Automation

### DIFF
--- a/AcsEmulator/AcsEmulatorAPI/Endpoints/CallAutomation/CallAutomationController.cs
+++ b/AcsEmulator/AcsEmulatorAPI/Endpoints/CallAutomation/CallAutomationController.cs
@@ -69,6 +69,37 @@ namespace AcsEmulatorAPI.Endpoints.CallAutomation
 
                 return Results.Accepted();
             });
+
+            app.MapGet("/calling/callConnections/{callConnectionId}", async (string callConnectionId, AcsDbContext db) =>
+            {
+                // Retrieve the CallConnection entity from the database based on the callConnectionId
+                var callConnection = await db.CallConnections.FindAsync(Guid.Parse(callConnectionId));
+
+                if (callConnection == null)
+                {
+                    // If the CallConnection entity is not found, return a 404 Not Found response
+                    return Results.NotFound("Call connection not found.");
+                }
+
+                // Return the CallConnection entity properties as the response
+                return Results.Ok(new
+                {
+                    callConnection.Id,
+                    callConnection.AnsweredBy,
+                    callConnection.CallConnectionState,
+                    callConnection.CallbackUri,
+                    callConnection.CorrelationId,
+                    callConnection.ServerCallId,
+                    callConnection.Source,
+                    callConnection.SourceCallerIdNumber,
+                    callConnection.SourceDisplayName,
+                    Targets = callConnection.Targets.Select(x => new CommunicationIdentifier(x.RawId)).ToArray()
+                });
+            });
+
+
+
+
         }
     }
 }


### PR DESCRIPTION
https://learn.microsoft.com/en-us/rest/api/communication/callautomation/call-connection/get-call?view=rest-communication-callautomation-2023-10-15&tabs=HTTP#callconnectionproperties

Given the callConnectionId , gets it from the db , else throws 404
When found in DB:
<img width="856" alt="image" src="https://github.com/DominikMe/acs-emulator/assets/99863251/340e8caf-bd55-4e99-a5cd-2cd6987dce17">

when not found in DB:
<img width="821" alt="image" src="https://github.com/DominikMe/acs-emulator/assets/99863251/0a418192-382c-4a49-b2ba-0adf4f66a805">
