### PR TITLE
Add workflow for creating GitHub Releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -6,10 +6,10 @@ on:
     inputs:
       # todo: get nupkgVersion dynamically
       nupkgVersion:
-        description: "Example: 0.1.0-alpha.20230510.1"
+        description: "nupkgVersion. Example: 0.1.0-alpha.20230510.1"
         required: true
       isPreRelease:
-        description: "Indicator of whether or not is a prerelease"
+        description: "isPreRelease. Indicator of whether or not this is a prerelease"
         required: true
         type: choice
         options:
@@ -62,7 +62,7 @@ jobs:
           name: AcsEmulatorCLI ${{ github.event.inputs.nupkgVersion }}
           prerelease: ${{ github.event.inputs.isPreRelease }}
           tag_name: v${{ github.event.inputs.nupkgVersion }}
-          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           files: |
             ./AcsEmulator/AcsEmulatorCLI/nupkg/AcsEmulatorCLI.${{ github.event.inputs.nupkgVersion }}.nupkg
           body: "

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,36 +66,37 @@ jobs:
           files: |
             ./AcsEmulator/AcsEmulatorCLI/nupkg/AcsEmulatorCLI.${{ github.event.inputs.nupkgVersion }}.nupkg
           body: "
-            # Emulator for Azure Communication Services
-            Local emulator to run Azure Communication Services client SDKs without having to provision an Azure Communication Services resource.
+# Emulator for Azure Communication Services
 
-            ## Download the emulator CLI tool
+Local emulator to run Azure Communication Services client SDKs without having to provision an Azure Communication Services resource.
 
-            ### Install from GitHub
+## Download the emulator CLI tool
 
-            Make sure you have the .NET Core SDK installed, download the latest [AcsEmulatorCLI Release](https://github.com/DominikMe/acs-emulator/releases) and then run from a terminal:
+### Install from GitHub
 
-            ```dotnetcli
-            dotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${{ github.event.inputs.nupkgVersion }}
-            ```
+Make sure you have the .NET Core SDK installed, download the latest [AcsEmulatorCLI Release](https://github.com/DominikMe/acs-emulator/releases) and then run from a terminal:
 
-            ### Running the tool
+```dotnetcli
+dotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${{ github.event.inputs.nupkgVersion }}
+```
 
-            **Usage:**
+### Running the tool
 
-            `acs-emulator [command] [options]`
+**Usage:**
 
-            **Commands:**
+`acs-emulator [command] [options]`
 
-            | Command            | Description                      |
-            | ------------------ | -------------------------------- |
-            |  `--version `        | Show version information
-            |  `-?, -h, --help`    | Show help and usage information |
-            |  `run`               | Run the emulator. |
-            |  `openApi`           | Open the emulator's API in Swagger UI. |
-            |  `openDB`            | Open the emulator's sqlite database.         |
-            |  `openUI`            | Open the emulator UI. |
-            |  `clean`             | Clean all data and reset the emulator state. |
-            |  `connectionString`  | Get the ACS connection string for the emulator. |
-            |  `repo`              | Open code repository. |
-          "
+**Commands:**
+
+| Command            | Description                      |
+| ------------------ | -------------------------------- |
+|  `--version `        | Show version information
+|  `-?, -h, --help`    | Show help and usage information |
+|  `run`               | Run the emulator. |
+|  `openApi`           | Open the emulator's API in Swagger UI. |
+|  `openDB`            | Open the emulator's sqlite database.         |
+|  `openUI`            | Open the emulator UI. |
+|  `clean`             | Clean all data and reset the emulator state. |
+|  `connectionString`  | Get the ACS connection string for the emulator. |
+|  `repo`              | Open code repository. |
+"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: windows-latest
     name: Create New Release
     steps:
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
 
       - name: Use Node.js v20
         uses: actions/setup-node@v4

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -76,17 +76,22 @@ Local emulator to run Azure Communication Services client SDKs without having to
 
 Make sure you have the .NET Core SDK installed, download the latest [AcsEmulatorCLI Release](https://github.com/DominikMe/acs-emulator/releases) and then run from a terminal:
 
+
 ```dotnetcli
 dotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${{ github.event.inputs.nupkgVersion }}
 ```
+
 
 ### Running the tool
 
 **Usage:**
 
+
 `acs-emulator [command] [options]`
 
+
 **Commands:**
+
 
 | Command            | Description                      |
 | ------------------ | -------------------------------- |
@@ -99,4 +104,6 @@ dotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${
 |  `clean`             | Clean all data and reset the emulator state. |
 |  `connectionString`  | Get the ACS connection string for the emulator. |
 |  `repo`              | Open code repository. |
+
+
 "

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,19 +7,32 @@ on:
       # todo: get nupkgVersion dynamically
       nupkgVersion:
         description: "Example: 0.1.0-alpha.20230510.1"
+        required: true
+      isPreRelease:
+        description: "Indicator of whether or not is a prerelease"
+        required: true
+        type: choice
+        options:
+          - true
+          - false
 
 jobs:
   publish:
     runs-on: windows-latest
     name: Create Release
     steps:
-      - name: Use Node.js v20.11.x
-        uses: actions/setup-node@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+      - name: Use Node.js v20
+        uses: actions/setup-node@v4
         with:
-          node-version: "20.11.x"
+          node-version: 20
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -27,6 +40,54 @@ jobs:
         working-directory: ./AcsEmulator/acs-emulator-ui
         run: npm install
 
-      - name: Build project
+      - name: Build UI Project
         working-directory: ./AcsEmulator/acs-emulator-ui
         run: npm run build
+      
+      - name: Build CLI project
+        working-directory: ./AcsEmulator
+        run: dotnet build AcsEmulatorCLI --configuration Release --property:Version=${{ github.event.inputs.nupkgVersion }}
+      
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: AcsEmulatorCLI ${{ github.event.inputs.nupkgVersion }}
+          prerelease: ${{ github.event.inputs.isPreRelease }}
+          tag_name: v${{ github.event.inputs.nupkgVersion }}
+          token: ${{ secrets.CUSTOM_GITHUB_TOKEN }}
+          files: |
+            ./AcsEmulator/AcsEmulatorCLI/nupkg/AcsEmulatorCLI.${{ github.event.inputs.nupkgVersion }}.nupkg
+          body: "
+            # Emulator for Azure Communication Services
+            Local emulator to run Azure Communication Services client SDKs without having to provision an Azure Communication Services resource.
+
+            ## Download the emulator CLI tool
+
+            ### Install from GitHub
+
+            Make sure you have the .NET Core SDK installed, download the latest [AcsEmulatorCLI Release](https://github.com/DominikMe/acs-emulator/releases) and then run from a terminal:
+
+            ```dotnetcli
+            dotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${{ github.event.inputs.nupkgVersion }}
+            ```
+
+            ### Running the tool
+
+            **Usage:**
+
+            `acs-emulator [command] [options]`
+
+            **Commands:**
+
+            | Command            | Description                      |
+            | ------------------ | -------------------------------- |
+            |  `--version `        | Show version information
+            |  `-?, -h, --help`    | Show help and usage information |
+            |  `run`               | Run the emulator. |
+            |  `openApi`           | Open the emulator's API in Swagger UI. |
+            |  `openDB`            | Open the emulator's sqlite database.         |
+            |  `openUI`            | Open the emulator UI. |
+            |  `clean`             | Clean all data and reset the emulator state. |
+            |  `connectionString`  | Get the ACS connection string for the emulator. |
+            |  `repo`              | Open code repository. |
+          "

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,32 @@
+# Prepares the Release artifacts, creates a new GitHub Release, and publishes the artifacts to the Release
+name: Create Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      # todo: get nupkgVersion dynamically
+      nupkgVersion:
+        description: "Example: 0.1.0-alpha.20230510.1"
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    name: Create Release
+    steps:
+      - name: Use Node.js v20.11.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: "20.11.x"
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install Emulator UI dependencies
+        working-directory: ./AcsEmulator/acs-emulator-ui
+        run: npm install
+
+      - name: Build project
+        working-directory: ./AcsEmulator/acs-emulator-ui
+        run: npm run build

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -66,37 +66,35 @@ jobs:
           files: |
             ./AcsEmulator/AcsEmulatorCLI/nupkg/AcsEmulatorCLI.${{ github.event.inputs.nupkgVersion }}.nupkg
           body: "
-# Emulator for Azure Communication Services
+            # Emulator for Azure Communication Services
 
-Local emulator to run Azure Communication Services client SDKs without having to provision an Azure Communication Services resource.
+            Local emulator to run Azure Communication Services client SDKs without having to provision an Azure Communication Services resource.
 
-## Download the emulator CLI tool
+            ## Download the emulator CLI tool
 
-### Install from GitHub
+            ### Install from GitHub
 
-Make sure you have the .NET Core SDK installed, download the latest [AcsEmulatorCLI Release](https://github.com/DominikMe/acs-emulator/releases) and then run from a terminal:
+            Make sure you have the .NET Core SDK installed, download the latest [AcsEmulatorCLI Release](https://github.com/DominikMe/acs-emulator/releases) and then run from a terminal:
 
-```dotnetcli\n
-dotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${{ github.event.inputs.nupkgVersion }}\n
-```
+            ```dotnetcli\ndotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${{ github.event.inputs.nupkgVersion }}\n```
 
-### Running the tool
+            ### Running the tool
 
-**Usage:**\n
+            **Usage:**\n
 
-`acs-emulator [command] [options]`
+            `acs-emulator [command] [options]`\n
 
-**Commands:**\n
+            **Commands:**\n
 
-| Command            | Description                      |\n
-| ------------------ | -------------------------------- |\n
-|  `--version `        | Show version information\n
-|  `-?, -h, --help`    | Show help and usage information |\n
-|  `run`               | Run the emulator. |\n
-|  `openApi`           | Open the emulator's API in Swagger UI. |\n
-|  `openDB`            | Open the emulator's sqlite database.         |\n
-|  `openUI`            | Open the emulator UI. |\n
-|  `clean`             | Clean all data and reset the emulator state. |\n
-|  `connectionString`  | Get the ACS connection string for the emulator. |\n
-|  `repo`              | Open code repository. |\n
-"
+            | Command            | Description                      |\n
+            | ------------------ | -------------------------------- |\n
+            |  `--version `        | Show version information\n
+            |  `-?, -h, --help`    | Show help and usage information |\n
+            |  `run`               | Run the emulator. |\n
+            |  `openApi`           | Open the emulator's API in Swagger UI. |\n
+            |  `openDB`            | Open the emulator's sqlite database.         |\n
+            |  `openUI`            | Open the emulator UI. |\n
+            |  `clean`             | Clean all data and reset the emulator state. |\n
+            |  `connectionString`  | Get the ACS connection string for the emulator. |\n
+            |  `repo`              | Open code repository. |\n
+          "

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -43,6 +43,14 @@ jobs:
       - name: Build UI Project
         working-directory: ./AcsEmulator/acs-emulator-ui
         run: npm run build
+
+      - name: Create Certificate
+        working-directory: ./AcsEmulator/AcsEmulatorAPI
+        run: ./createSelfSignedCert.ps1
+
+      - name: Restore Dependencies
+        working-directory: ./AcsEmulator
+        run: dotnet restore
       
       - name: Build CLI project
         working-directory: ./AcsEmulator

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -76,34 +76,27 @@ Local emulator to run Azure Communication Services client SDKs without having to
 
 Make sure you have the .NET Core SDK installed, download the latest [AcsEmulatorCLI Release](https://github.com/DominikMe/acs-emulator/releases) and then run from a terminal:
 
-
-```dotnetcli
-dotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${{ github.event.inputs.nupkgVersion }}
+```dotnetcli\n
+dotnet tool install -g --add-source [downloadFolder] AcsEmulatorCLI --version ${{ github.event.inputs.nupkgVersion }}\n
 ```
-
 
 ### Running the tool
 
-**Usage:**
-
+**Usage:**\n
 
 `acs-emulator [command] [options]`
 
+**Commands:**\n
 
-**Commands:**
-
-
-| Command            | Description                      |
-| ------------------ | -------------------------------- |
-|  `--version `        | Show version information
-|  `-?, -h, --help`    | Show help and usage information |
-|  `run`               | Run the emulator. |
-|  `openApi`           | Open the emulator's API in Swagger UI. |
-|  `openDB`            | Open the emulator's sqlite database.         |
-|  `openUI`            | Open the emulator UI. |
-|  `clean`             | Clean all data and reset the emulator state. |
-|  `connectionString`  | Get the ACS connection string for the emulator. |
-|  `repo`              | Open code repository. |
-
-
+| Command            | Description                      |\n
+| ------------------ | -------------------------------- |\n
+|  `--version `        | Show version information\n
+|  `-?, -h, --help`    | Show help and usage information |\n
+|  `run`               | Run the emulator. |\n
+|  `openApi`           | Open the emulator's API in Swagger UI. |\n
+|  `openDB`            | Open the emulator's sqlite database.         |\n
+|  `openUI`            | Open the emulator UI. |\n
+|  `clean`             | Clean all data and reset the emulator state. |\n
+|  `connectionString`  | Get the ACS connection string for the emulator. |\n
+|  `repo`              | Open code repository. |\n
 "

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,7 +19,7 @@ on:
 jobs:
   publish:
     runs-on: windows-latest
-    name: Create Release
+    name: Create New Release
     steps:
     - name: Setup .NET
       uses: actions/setup-dotnet@v4

--- a/AcsEmulator/acs-emulator-ui/src/components/Phone.tsx
+++ b/AcsEmulator/acs-emulator-ui/src/components/Phone.tsx
@@ -15,8 +15,6 @@ const SpeechRecognition =
   window.SpeechRecognition || window.webkitSpeechRecognition;
 const SpeechGrammarList =
   window.SpeechGrammarList || window.webkitSpeechGrammarList;
-const SpeechRecognitionEvent =
-  window.SpeechRecognitionEvent || window.webkitSpeechRecognitionEvent;
 
 interface ActiveCall { 
   callerId: string,
@@ -41,6 +39,31 @@ export const Phone = () => {
     (async () => {
       const connection = await establishPhoneConnection(phoneNumber);
       connection.webSocket.onmessage = (event) => {
+        const handleMessage = (event: MessageEvent) => {
+          const message = JSON.parse(event.data);
+          console.log(message);
+      
+          switch (message.action) {
+            case 'incomingCall':
+              setActiveCall({
+                callerId: message.callerId,
+                callerDisplayName: message.callerDisplayName,
+                startTime: new Date(message.time),
+                callState: 'ringing'
+              });
+              navigate('/PhoneUI/incomingCall');
+              break;
+            case 'playText':
+              // todo: check that call is connected, skipping for now until we have the full client to service flow
+              textToSpeech(message.text);
+              break;
+            case 'recognizeSpeech':
+                // todo: check that call is connected, skipping for now until we have the full client to service flow
+                recognizeSpeech(message.choices, message.prompt);
+                break;
+          }
+        };
+
         handleMessage(event);
       };
       phoneConnection.current = connection;
@@ -132,31 +155,6 @@ export const Phone = () => {
 
     rec.start();
   }
-
-  const handleMessage = (event: MessageEvent) => {
-    const message = JSON.parse(event.data);
-    console.log(message);
-
-    switch (message.action) {
-      case 'incomingCall':
-        setActiveCall({
-          callerId: message.callerId,
-          callerDisplayName: message.callerDisplayName,
-          startTime: new Date(message.time),
-          callState: 'ringing'
-        });
-        navigate('/PhoneUI/incomingCall');
-        break;
-      case 'playText':
-        // todo: check that call is connected, skipping for now until we have the full client to service flow
-        textToSpeech(message.text);
-        break;
-      case 'recognizeSpeech':
-          // todo: check that call is connected, skipping for now until we have the full client to service flow
-          recognizeSpeech(message.choices, message.prompt);
-          break;
-    }
-  };
 
   const incomingCallTokens: IStackTokens = {
     childrenGap: 10,

--- a/AcsEmulator/acs-emulator-ui/src/components/Phone.tsx
+++ b/AcsEmulator/acs-emulator-ui/src/components/Phone.tsx
@@ -39,35 +39,12 @@ export const Phone = () => {
     (async () => {
       const connection = await establishPhoneConnection(phoneNumber);
       connection.webSocket.onmessage = (event) => {
-        const handleMessage = (event: MessageEvent) => {
-          const message = JSON.parse(event.data);
-          console.log(message);
-      
-          switch (message.action) {
-            case 'incomingCall':
-              setActiveCall({
-                callerId: message.callerId,
-                callerDisplayName: message.callerDisplayName,
-                startTime: new Date(message.time),
-                callState: 'ringing'
-              });
-              navigate('/PhoneUI/incomingCall');
-              break;
-            case 'playText':
-              // todo: check that call is connected, skipping for now until we have the full client to service flow
-              textToSpeech(message.text);
-              break;
-            case 'recognizeSpeech':
-                // todo: check that call is connected, skipping for now until we have the full client to service flow
-                recognizeSpeech(message.choices, message.prompt);
-                break;
-          }
-        };
-
         handleMessage(event);
       };
       phoneConnection.current = connection;
     })();
+    // todo: more gracefully resolve eslint error
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const callNumber = () => {
@@ -155,6 +132,31 @@ export const Phone = () => {
 
     rec.start();
   }
+
+  const handleMessage = (event: MessageEvent) => {
+    const message = JSON.parse(event.data);
+    console.log(message);
+
+    switch (message.action) {
+      case 'incomingCall':
+        setActiveCall({
+          callerId: message.callerId,
+          callerDisplayName: message.callerDisplayName,
+          startTime: new Date(message.time),
+          callState: 'ringing'
+        });
+        navigate('/PhoneUI/incomingCall');
+        break;
+      case 'playText':
+        // todo: check that call is connected, skipping for now until we have the full client to service flow
+        textToSpeech(message.text);
+        break;
+      case 'recognizeSpeech':
+          // todo: check that call is connected, skipping for now until we have the full client to service flow
+          recognizeSpeech(message.choices, message.prompt);
+          break;
+    }
+  };
 
   const incomingCallTokens: IStackTokens = {
     childrenGap: 10,


### PR DESCRIPTION
**SUMMARY**
- New 'Create Release' workflow to make it easier to publish new releases of the emulator
- Sample Release: https://github.com/ralphgabrinao/acs-emulator/releases
- Re: ESLint workaround in Phone.tsx -- warnings are considered as errors in the CI, so for now just telling ESLint to ignore the rule

**Release screenshot**
![2024-03-20 16_26_52-Release AcsEmulatorCLI 0 1 0-alpha 20240320 5 · ralphgabrinao_acs-emulator and 1](https://github.com/DominikMe/acs-emulator/assets/43504546/09025ed1-701b-429e-82e7-c531663349c3)

**Downloading, installing, and running emulator cli from Release**
![2024-03-20 16_33_37-Comparing DominikMe_main ralphgabrinao_main · DominikMe_acs-emulator and 20 mo](https://github.com/DominikMe/acs-emulator/assets/43504546/68b08087-4c3a-46d5-93ce-b53ac001ebcd)

**ESLint errors**
![2024-03-20 13_55_27-Phone tsx - acs-emulator - Visual Studio Code](https://github.com/DominikMe/acs-emulator/assets/43504546/66b152cf-2b24-43e7-9d2b-103e6a9457e4)
